### PR TITLE
Update LAB_02L05_Create_and_manage_session_host_images_ADDS.md

### DIFF
--- a/Instructions/Labs/LAB_02L05_Create_and_manage_session_host_images_ADDS.md
+++ b/Instructions/Labs/LAB_02L05_Create_and_manage_session_host_images_ADDS.md
@@ -221,7 +221,7 @@ Deploy the Teams desktop app to the VM](https://docs.microsoft.com/en-us/microso
 
    > **Note**: Wait for the deployment to complete. This might take about 20 minutes.
 
-1. From your lab computer, in the web browser displaying the Azure portal, search for and select **Shared image galleries** and, on the **Shared image galleries** blade, select the **az14025imagegallery** entry, and, on the ****az14025imagegallery**** blade, verify the presence of the **az140-25-host-image** entry representing the newly created image.
+1. From your lab computer, in the web browser displaying the Azure portal, search for and select **Azure compute galleries** and, on the **Azure compute galleries** blade, select the **az14025imagegallery** entry, and, on the ****az14025imagegallery**** blade, verify the presence of the **az140-25-host-image** entry representing the newly created image.
 
 #### Task 4: Provision a Azure Virtual Desktop host pool by using a custom image
 


### PR DESCRIPTION
"Shared image galleries" is now called "Azure compute galleries2

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

- "Shared image galleries" is now called "Azure compute galleries"
-
-