### PR TITLE
Update LAB_04L02_Package_AVD_applications_ADDS.md

### DIFF
--- a/Instructions/Labs/LAB_04L02_Package_AVD_applications_ADDS.md
+++ b/Instructions/Labs/LAB_04L02_Package_AVD_applications_ADDS.md
@@ -33,8 +33,8 @@ After completing this lab, you will be able to:
 
 ## Lab files
 
--  \\\\AZ-140\\AllFiles\\Labs\\04\\az140-42_azuredeploycl42.json
--  \\\\AZ-140\\AllFiles\\Labs\\04\\az140-42_azuredeploycl42.parameters.json
+-  \\\\AZ-140\\AllFiles\\Labs\\04\\az140-42_azuredeploycl42.json - Remove Public IP connected to az140-cl-vm42
+-  \\\\AZ-140\\AllFiles\\Labs\\04\\az140-42_azuredeploycl42.parameters.json - - Remove Public IP connected to az140-cl-vm42
 
 ## Instructions
 


### PR DESCRIPTION
 The az140-42_azuredeploycl42.json and az140-42_azuredeploycl42.parameters.json files are deploying a VM - az140-cl-vm42 with a Public IP address, even though the instructions suggest to leverage Bastion host. This opens a big security problem. 
Please remove the Public IP references from the JSON files

# Module: 04
## Lab/Demo: LAB_04L02

Fixes # .

Changes proposed in this pull request:

-Remove Public IP address connected to VM az140-cl-vm42
-
-