### PR TITLE
Update LAB_04L01_Implement_and_manage_AVD_profiles_AADDS.md

### DIFF
--- a/Instructions/Labs/LAB_04L01_Implement_and_manage_AVD_profiles_AADDS.md
+++ b/Instructions/Labs/LAB_04L01_Implement_and_manage_AVD_profiles_AADDS.md
@@ -172,7 +172,6 @@ and select **OK** to close the group **Properties** window.
    ```
 
 1. Within the Remote Desktop session to **az140-21-p1-0**, start **Windows PowerShell ISE** as administrator and, from the **Administrator: Windows PowerShell ISE** script pane, run the following to configure profile registry settings on the **az140-21-p1-1** session host:
->**Note**: Replace <storageAccountName> with actual name of your storage account.
 
    ```powershell
    $profilesParentKey = 'HKLM:\SOFTWARE\FSLogix'
@@ -181,7 +180,7 @@ and select **OK** to close the group **Properties** window.
    Invoke-Command -ComputerName $server -ScriptBlock {
       New-Item -Path $using:profilesParentKey -Name $using:profilesChildKey –Force
       New-ItemProperty -Path $using:profilesParentKey\$using:profilesChildKey -Name 'Enabled' -PropertyType DWord -Value 1
-      New-ItemProperty -Path $using:profilesParentKey\$using:profilesChildKey -Name 'VHDLocations' -PropertyType MultiString -Value "\\<storageAccountName>.file.core.windows.net\$using:fileShareName"
+      New-ItemProperty -Path $using:profilesParentKey\$using:profilesChildKey -Name 'VHDLocations' -PropertyType MultiString -Value "\\$storageAccountName.file.core.windows.net\$using:fileShareName"
    }
    ```
 

--- a/Instructions/Labs/LAB_04L01_Implement_and_manage_AVD_profiles_AADDS.md
+++ b/Instructions/Labs/LAB_04L01_Implement_and_manage_AVD_profiles_AADDS.md
@@ -66,7 +66,7 @@ The main tasks for this exercise are as follows:
    |Group scope|**Global**|
    |Group type|**Security**|
 
-1. In the **Active Directory Users and Computers** console, display the properties of the **Local Admins** group, switch to the **Members** tab, select **Add**, in the **Select Users, Contacts, Computers, Service Accounts, or Groups** dialog box, in the **Enter the object names to select**, type **aadadmin1** and select **OK**.
+1. In the **Active Directory Users and Computers** console, display the properties of the **Local Admins** group, switch to the **Members** tab, select **Add**, in the **Select Users, Contacts, Computers, Service Accounts, or Groups** dialog box, in the **Enter the object names to select**, type **aadadmin1;wvdaadmin1** and select **OK**.
 1. Within the Remote Desktop session to **az140-cl-vm11a**, in the Start menu, navigate to the **Windows Administration Tools** folder, expand it, and select **Group Policy Management**.
 1. In the **Group Policy Management** console, navigate to the **AADDC Computers** OU, right-click the **AADDC Computers GPO** icon and select **Edit**.
 1. In the **Group Policy Management Editor** console, expand **Computer Configuration**, **Policies**, **Windows Settings**, **Security Settings**, right-click **Restriced Groups**, and select **Add Group**.


### PR DESCRIPTION
If wvdaadmin1 is not added as a member of Local Admins, they cannot log on via remote desktop in Task 2

# Module: 04L01
## Lab/Demo: Implement and manage AVD profiles AADDS
### Exercise 1
#### Task 1
##### Step 8

Changes proposed in this pull request:

- If wvdaadmin1 is not added to Local Admins, they cannot use Remote Desktop or install FSLogix in Task 2
- Used the storage account name variable in Task 2, Step 9