### PR TITLE
Update LAB_01L01_Prepare_for_deployment_of_AVD_ADDS - use single quotes

### DIFF
--- a/Instructions/Labs/LAB_01L01_Prepare_for_deployment_of_AVD_ADDS.md
+++ b/Instructions/Labs/LAB_01L01_Prepare_for_deployment_of_AVD_ADDS.md
@@ -263,14 +263,14 @@ The main tasks for this exercise are as follows:
    foreach ($counter in $userCount) {
      New-AdUser -Name $adUserNamePrefix$counter -Path $ouPath -Enabled $True `
        -ChangePasswordAtLogon $false -userPrincipalName $adUserNamePrefix$counter@$adUPNSuffix `
-       -AccountPassword (ConvertTo-SecureString "<password>" -AsPlainText -Force) -passThru
+       -AccountPassword (ConvertTo-SecureString '<password>' -AsPlainText -Force) -passThru
    } 
 
    $adUserNamePrefix = 'wvdadmin1'
    $adUPNSuffix = 'adatum.com'
    New-AdUser -Name $adUserNamePrefix -Path $ouPath -Enabled $True `
        -ChangePasswordAtLogon $false -userPrincipalName $adUserNamePrefix@$adUPNSuffix `
-       -AccountPassword (ConvertTo-SecureString "<password>" -AsPlainText -Force) -passThru
+       -AccountPassword (ConvertTo-SecureString '<password>' -AsPlainText -Force) -passThru
 
    Get-ADGroup -Identity 'Domain Admins' | Add-AdGroupMember -Members 'wvdadmin1'
    ```


### PR DESCRIPTION
Change to single quote to prevent problems with characters in passwords.

# Module: 01
## Lab/Demo: 01 AVD_ADDS


Changes proposed in this pull request:

- Use single quotes around the <password> to prevent problems if the student uses certain characters.
