### PR TITLE
Update LAB_02L05_Create_and_manage_session_host_images_ADDS.md

### DIFF
--- a/Instructions/Labs/LAB_02L05_Create_and_manage_session_host_images_ADDS.md
+++ b/Instructions/Labs/LAB_02L05_Create_and_manage_session_host_images_ADDS.md
@@ -221,7 +221,7 @@ Deploy the Teams desktop app to the VM](https://docs.microsoft.com/en-us/microso
 1. Within the Remote Desktop session to **az140-25-vm0**, in the **Administrator: C:\windows\system32\cmd.exe** window, from the command prompt, run the sysprep utility in order to prepare the operating system for generating an image and automatically shut it down:
 
    ```cmd
-   C:\Windows\System32\Sysprep\sysprep.exe /oobe /generalize /shutdown
+   C:\Windows\System32\Sysprep\sysprep.exe /oobe /generalize /shutdown /mode:vm
    ```
 
    > **Note**: Wait for the sysprep process to complete. This might take about 2 minutes. This will automatically shut down the operating system. 


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

If the image is used on the same platform (Azure), the switch /mode:vm could be added. So that the Windows installer does not have to search for changed hardware. Just a suggestion.