### PR TITLE
Fix long dash to short version

### DIFF
--- a/Instructions/Labs/LAB_01L01_Prepare_for_deployment_of_AVD_AADDS.md
+++ b/Instructions/Labs/LAB_01L01_Prepare_for_deployment_of_AVD_AADDS.md
@@ -85,7 +85,7 @@ The main tasks for this exercise are as follows:
 
 1. In the Azure portal, search for and select **Subscriptions** and, from the **Subscriptions** blade, select the entry representing the Azure subscription you intend to use for this lab.
 1. In the Azure portal, on the subscription blade, in the vertical menu on the left side, in the **Settings** section, select **Usage + quotas**. 
-1. On the **Azure Pass – Sponsorship | Usage + quotas** blade, select the following drop down arrows from the top search bar:
+1. On the **Azure Pass - Sponsorship | Usage + quotas** blade, select the following drop down arrows from the top search bar:
 
    |**Setting**|**Value**|
    |---|---|

--- a/Instructions/Labs/LAB_01L01_Prepare_for_deployment_of_AVD_ADDS.md
+++ b/Instructions/Labs/LAB_01L01_Prepare_for_deployment_of_AVD_ADDS.md
@@ -90,7 +90,7 @@ The main tasks for this exercise are as follows:
 
    **Note:** Requesting quota increase requires signing-in with multi-factor authentication (MFA). If you need to configure your account with MFA, refer to [Plan an Azure Active Directory Multi-Factor Authentication deployment](https://learn.microsoft.com/en-us/azure/active-directory/authentication/howto-mfa-getstarted). 
    
-1. On the **Azure Pass – Sponsorship | Usage + quotas** blade, select **Region**, in the drop down list, select the checkbox next to the name of the Azure region you intend to use for this lab, select **Apply**, ensure that the **Compute** entry appears in the drop down list to the left of the **Region** entry, and, in the search box, type **Standard DSv3**. 
+1. On the **Azure Pass - Sponsorship | Usage + quotas** blade, select **Region**, in the drop down list, select the checkbox next to the name of the Azure region you intend to use for this lab, select **Apply**, ensure that the **Compute** entry appears in the drop down list to the left of the **Region** entry, and, in the search box, type **Standard DSv3**. 
 1. In the list of results, select the checkbox next to the **Standard DSv3 Family vCPUs** item, select the **Request quota increase** entry in the toolbar, and, in the drop down list, select **Enter a new limit**.
 1. In the **Request quota increase** pane, in the **New limit** column text box, type **30**, and then select **Submit**.
 1. If prompted, on the **Request quota increase** pane, select **Authenticate with Multi-Factory Authentication** and follow the prompts to authenticate.

--- a/Instructions/Labs/LAB_02L01_Deploy_host_pools_and_session_hosts_with_the_Azure_portal_ADDS.md
+++ b/Instructions/Labs/LAB_02L01_Deploy_host_pools_and_session_hosts_with_the_Azure_portal_ADDS.md
@@ -60,7 +60,7 @@ The main tasks for this exercise are as follows:
 1. Within the Bastion session to **az140-dc-vm11**, from the **Administrator: Windows PowerShell ISE** console, run the following to create an organizational unit that will host the computer objects of the Azure Virtual Desktop hosts:
 
    ```powershell
-   New-ADOrganizationalUnit 'WVDInfra' –path 'DC=adatum,DC=com' -ProtectedFromAccidentalDeletion $false
+   New-ADOrganizationalUnit 'WVDInfra' -path 'DC=adatum,DC=com' -ProtectedFromAccidentalDeletion $false
    ```
 
 1. From the **Administrator: Windows PowerShell ISE** console, run the following to identify the user principal name of the **aduser1** account:

--- a/Instructions/Labs/LAB_04L01_Implement_and_manage_AVD_profiles_AADDS.md
+++ b/Instructions/Labs/LAB_04L01_Implement_and_manage_AVD_profiles_AADDS.md
@@ -155,7 +155,7 @@ The main tasks for this exercise are as follows:
    $profilesParentKey = 'HKLM:\SOFTWARE\FSLogix'
    $profilesChildKey = 'Profiles'
    $fileShareName = 'az140-22a-profiles'
-   New-Item -Path $profilesParentKey -Name $profilesChildKey –Force
+   New-Item -Path $profilesParentKey -Name $profilesChildKey -Force
    New-ItemProperty -Path $profilesParentKey\$profilesChildKey -Name 'Enabled' -PropertyType DWord -Value 1
    New-ItemProperty -Path $profilesParentKey\$profilesChildKey -Name 'VHDLocations' -PropertyType MultiString -Value "\\$storageAccountName.file.core.windows.net\$fileShareName"
    ```
@@ -199,7 +199,7 @@ and select **OK** to close the group **Properties** window.
    $profilesChildKey = 'Profiles'
    $fileShareName = 'az140-22a-profiles'
    Invoke-Command -ComputerName $server -ScriptBlock {
-      New-Item -Path $using:profilesParentKey -Name $using:profilesChildKey –Force
+      New-Item -Path $using:profilesParentKey -Name $using:profilesChildKey -Force
       New-ItemProperty -Path $using:profilesParentKey\$using:profilesChildKey -Name 'Enabled' -PropertyType DWord -Value 1
       New-ItemProperty -Path $using:profilesParentKey\$using:profilesChildKey -Name 'VHDLocations' -PropertyType MultiString -Value "\\$storageAccountName.file.core.windows.net\$using:fileShareName"
    }

--- a/Instructions/Labs/LAB_04L01_Implement_and_manage_AVD_profiles_ADDS.md
+++ b/Instructions/Labs/LAB_04L01_Implement_and_manage_AVD_profiles_ADDS.md
@@ -108,7 +108,7 @@ The main tasks for this exercise are as follows:
    $profilesParentKey = 'HKLM:\SOFTWARE\FSLogix'
    $profilesChildKey = 'Profiles'
    $fileShareName = 'az140-22-profiles'
-   New-Item -Path $profilesParentKey -Name $profilesChildKey –Force
+   New-Item -Path $profilesParentKey -Name $profilesChildKey -Force
    New-ItemProperty -Path $profilesParentKey\$profilesChildKey -Name 'Enabled' -PropertyType DWord -Value 1
    New-ItemProperty -Path $profilesParentKey\$profilesChildKey -Name 'VHDLocations' -PropertyType MultiString -Value "\\$storageAccountName.file.core.windows.net\$fileShareName"
    ```
@@ -158,7 +158,7 @@ The main tasks for this exercise are as follows:
    $fileShareName = 'az140-22-profiles'
    foreach ($server in $servers) {
       Invoke-Command -ComputerName $server -ScriptBlock {
-         New-Item -Path $using:profilesParentKey -Name $using:profilesChildKey –Force
+         New-Item -Path $using:profilesParentKey -Name $using:profilesChildKey -Force
          New-ItemProperty -Path $using:profilesParentKey\$using:profilesChildKey -Name 'Enabled' -PropertyType DWord -Value 1
          New-ItemProperty -Path $using:profilesParentKey\$using:profilesChildKey -Name 'VHDLocations' -PropertyType MultiString -Value "\\$using:storageAccountName.file.core.windows.net\$using:fileShareName"
       }


### PR DESCRIPTION
Replace long dashes with short dashes to avoid PowerShell issues in ALHs and to ensure consistency and accuracy in the provided commands and instructions.

### Typographical corrections:

* Corrected the dash character in the instructions for selecting options on the **Azure Pass - Sponsorship | Usage + quotas** blade in `LAB_01L01_Prepare_for_deployment_of_AVD_AADDS.md` and `LAB_01L01_Prepare_for_deployment_of_AVD_ADDS.md`. [[1]](diffhunk://#diff-8d210ffca3655f267065dfd48cb032165654fd9a76d0c1c16e9e06ae433dac27L88-R88) [[2]](diffhunk://#diff-a7275cb964ce20d844ad119b6b3df02b9c12f74401081a941fb156591fffe9a8L93-R93)

### Command corrections:

* Fixed the dash character in the `New-ADOrganizationalUnit` PowerShell command in `LAB_02L01_Deploy_host_pools_and_session_hosts_with_the_Azure_portal_ADDS.md`.
* Corrected the dash character in the `New-Item` PowerShell command in `LAB_04L01_Implement_and_manage_AVD_profiles_AADDS.md`. [[1]](diffhunk://#diff-feb41575ea759d38fcc026b883ee002df0c607644d9f722368a194d70f0dcc5bL158-R158) [[2]](diffhunk://#diff-feb41575ea759d38fcc026b883ee002df0c607644d9f722368a194d70f0dcc5bL202-R202)
* Corrected the dash character in the `New-Item` PowerShell command in `LAB_04L01_Implement_and_manage_AVD_profiles_ADDS.md`. [[1]](diffhunk://#diff-852790010dd56e582131c79e2dad129501ac3dd23abca0ab3a0cc94ebaf13fc9L111-R111) [[2]](diffhunk://#diff-852790010dd56e582131c79e2dad129501ac3dd23abca0ab3a0cc94ebaf13fc9L161-R161)