### PR TITLE
Alternative update to index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,9 +8,29 @@ layout: home
 
 Hyperlinks to each of the lab exercises and demos are listed below.
 
-## Labs
+## Labs \(Entra ID\)
 
 {% assign labs = site.pages | where_exp:"page", "page.url contains '/Instructions/Labs_EntraID'" %}
+| Module | Lab |
+| --- | --- | 
+{% for activity in labs  %}| {{ activity.lab.module }} | [{{ activity.lab.title }}{% if activity.lab.type %} - {{ activity.lab.type }}{% endif %}]({{ site.github.url }}{{ activity.url }}) |
+{% endfor %}
+
+## Labs \(AD DS\)
+
+Required labs files can be [DOWNLOADED HERE](https://github.com/MicrosoftLearning/AZ-140-Configuring-and-Operating-Microsoft-Azure-Virtual-Desktop/archive/master.zip)
+
+{% assign labs = site.pages | where_exp:"page", "page.url contains '_ADDS'" %}
+| Module | Lab |
+| --- | --- | 
+{% for activity in labs  %}| {{ activity.lab.module }} | [{{ activity.lab.title }}{% if activity.lab.type %} - {{ activity.lab.type }}{% endif %}]({{ site.github.url }}{{ activity.url }}) |
+{% endfor %}
+
+## Labs \(Entra DS\)
+
+Required labs files can be [DOWNLOADED HERE](https://github.com/MicrosoftLearning/AZ-140-Configuring-and-Operating-Microsoft-Azure-Virtual-Desktop/archive/master.zip)
+
+{% assign labs = site.pages | where_exp:"page", "page.url contains '_AADDS'" %}
 | Module | Lab |
 | --- | --- | 
 {% for activity in labs  %}| {{ activity.lab.module }} | [{{ activity.lab.title }}{% if activity.lab.type %} - {{ activity.lab.type }}{% endif %}]({{ site.github.url }}{{ activity.url }}) |

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ Hyperlinks to each of the lab exercises and demos are listed below.
 
 ## Labs
 
-{% assign labs = site.pages | where_exp:"page", "page.url contains '/Instructions/Labs'" %}
+{% assign labs = site.pages | where_exp:"page", "page.url contains '/Instructions/Labs_EntraID'" %}
 | Module | Lab |
 | --- | --- | 
 {% for activity in labs  %}| {{ activity.lab.module }} | [{{ activity.lab.title }}{% if activity.lab.type %} - {{ activity.lab.type }}{% endif %}]({{ site.github.url }}{{ activity.url }}) |


### PR DESCRIPTION
This is an alternative to #308 that lists all labs, grouped together appropriately. 
I really like the AD DS labs and will be sorry to see them go, but they are still viable for a student using their own account.